### PR TITLE
allow deny

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ class CreateUser
   # input filtering, coercion, and basic validations are defined here
   filter do
     string :name
-    date :birthday, nils: ALLOW
+    date :birthday, nils: allow
     hash :settings do
       string :home_page
       integer :version, nils: 2
@@ -171,10 +171,10 @@ Here, we pass two hashes to CreateComment. Even if the params[:comment] hash has
     integer :age
     boolean :is_special, nils: true
     model :account
-    array :tags, nils: ALLOW do
+    array :tags, nils: allow do
       string
     end
-    hash :prefs, nils: ALLOW do
+    hash :prefs, nils: allow do
       boolean :smoking
       boolean :view
     end

--- a/lib/objective/filter.rb
+++ b/lib/objective/filter.rb
@@ -29,6 +29,14 @@ module Objective
       @options ||= OpenStruct.new(self.class.const_get('Options').to_h.merge(@given_options))
     end
 
+    def allow
+      Objective::ALLOW
+    end
+
+    def deny
+      Objective::DENY
+    end
+
     def sub_filters_hash
       sub_filters.each_with_object({}) { |sf, result| result[sf.key] = sf }
     end
@@ -37,14 +45,6 @@ module Objective
       dupped = self.class.new
       sub_filters.each { |sf| dupped.sub_filters.push(sf) }
       dupped
-    end
-
-    def default?
-      options.to_h.key?(:default)
-    end
-
-    def default
-      options.default
     end
 
     def feed(raw)
@@ -62,10 +62,10 @@ module Objective
 
     def feed_nil
       case options.nils
-      when Objective::ALLOW
+      when allow
         errors = nil
         coerced = nil
-      when Objective::DENY
+      when deny
         errors = :nils
         coerced = nil
       else
@@ -78,9 +78,9 @@ module Objective
 
     def feed_invalid(errors, raw, coerced)
       case options.invalid
-      when Objective::ALLOW
+      when allow
         errors = nil
-      when Objective::DENY
+      when deny
         nil
       else
         errors = nil
@@ -92,9 +92,9 @@ module Objective
 
     def feed_empty(raw, coerced)
       case options.empty
-      when Objective::ALLOW
+      when allow
         errors = nil
-      when Objective::DENY
+      when deny
         errors = :empty
       else
         coerced = options.empty

--- a/lib/objective/unit.rb
+++ b/lib/objective/unit.rb
@@ -6,8 +6,6 @@ module Objective
       base.extend ClassMethods
       base.class_eval do
         attr_reader :inputs, :raw_inputs
-        const_set('ALLOW', Objective::ALLOW)
-        const_set('DENY', Objective::DENY)
       end
     end
 

--- a/test/objective/errors/errors_test.rb
+++ b/test/objective/errors/errors_test.rb
@@ -5,17 +5,18 @@ require 'test_helper'
 describe 'Objective - errors' do
   class GivesErrors
     include Objective::Unit
+
     filter do
       string :str1
       string :str2, in: %w[opt1 opt2 opt3]
-      integer :int1, nils: ALLOW
+      integer :int1, nils: allow
 
-      hash :hash1, nils: ALLOW do
+      hash :hash1, nils: allow do
         boolean :bool1
         boolean :bool2
       end
 
-      array :arr1, nils: ALLOW do
+      array :arr1, nils: allow do
         integer
       end
     end

--- a/test/objective/filters/root_filter_test.rb
+++ b/test/objective/filters/root_filter_test.rb
@@ -46,7 +46,7 @@ describe 'Objective::Filters::RootFilter' do
       f = Objective::Filters::RootFilter.new do
         filter do
           string :foo
-          string :bar, nils: Objective::ALLOW
+          string :bar, nils: allow
         end
       end
 
@@ -59,7 +59,7 @@ describe 'Objective::Filters::RootFilter' do
       f = Objective::Filters::RootFilter.new do
         filter do
           string :foo
-          string :bar, nils: Objective::ALLOW
+          string :bar, nils: allow
         end
       end
 
@@ -74,7 +74,7 @@ describe 'Objective::Filters::RootFilter' do
       f = Objective::Filters::RootFilter.new do
         filter do
           string :foo
-          string :bar, empty: Objective::ALLOW
+          string :bar, empty: allow
         end
       end
 
@@ -87,7 +87,7 @@ describe 'Objective::Filters::RootFilter' do
       f = Objective::Filters::RootFilter.new do
         filter do
           string :foo
-          string :bar, empty: Objective::ALLOW, nils: ''
+          string :bar, empty: allow, nils: ''
         end
       end
 

--- a/test/objective/unit_test.rb
+++ b/test/objective/unit_test.rb
@@ -8,7 +8,7 @@ class SimpleUnit
   filter do
     string :name, max: 10
     string :email
-    integer :amount, nils: ALLOW
+    integer :amount, nils: allow
   end
 
   def validate
@@ -168,9 +168,10 @@ describe 'Unit' do
   describe 'EigenUnit' do
     class EigenUnit
       include Objective::Unit
+
       filter do
         string :name
-        string :email, nils: ALLOW
+        string :email, nils: allow
       end
 
       def execute
@@ -187,9 +188,10 @@ describe 'Unit' do
   describe 'MutatatedUnit' do
     class MutatatedUnit
       include Objective::Unit
+
       filter do
         string :name
-        string :email, nils: ALLOW
+        string :email, nils: allow
       end
 
       def execute
@@ -208,9 +210,10 @@ describe 'Unit' do
   describe 'ErrorfulUnit' do
     class ErrorfulUnit
       include Objective::Unit
+
       filter do
         string :name
-        string :email, nils: ALLOW
+        string :email, nils: allow
       end
 
       def execute
@@ -231,9 +234,10 @@ describe 'Unit' do
   describe 'NestingErrorfulUnit' do
     class NestingErrorfulUnit
       include Objective::Unit
+
       filter do
         string :name
-        string :email, nils: ALLOW
+        string :email, nils: allow
       end
 
       def execute
@@ -254,9 +258,10 @@ describe 'Unit' do
   describe 'MultiErrorUnit' do
     class MultiErrorUnit
       include Objective::Unit
+
       filter do
         string :name
-        string :email, nils: ALLOW
+        string :email, nils: allow
       end
 
       def execute
@@ -282,6 +287,7 @@ describe 'Unit' do
   describe 'RawInputsUnit' do
     class RawInputsUnit
       include Objective::Unit
+
       filter do
         string :name
       end


### PR DESCRIPTION
1. When a module has a filter but Objective::Unit is not included directly to that class, `ALLOW` and `DENY` are not available to the module and cause an error.
2. This decreases the 'fingerprint' of include `Objective::Unit` into a class. A user can now use `ALLOW` and `DENY` constant names for their own purposes.
3. I believe the ergonomics are slightly better